### PR TITLE
prepare release 3.1.2

### DIFF
--- a/EgoiPushLibrary/build.gradle
+++ b/EgoiPushLibrary/build.gradle
@@ -63,7 +63,7 @@ afterEvaluate {
 
                 groupId = 'com.egoiapp.egoipushlibrary'
                 artifactId = 'egoipushlibrary'
-                version = '3.1.1'
+                version = '3.1.2'
 
                 pom {
                     name = "EgoiPushLibrary"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# What's new in version 3.1.1?
+# What's new in version 3.1.2?
 
 ### PATCH
 
-#### Close action not working:
+#### Add result return from register token request:
 
-Fix a bug where when pressing the close action of a notification when the app is closed, notification is not dismissed.
+Added the possibility to have the response to the register token request result.
+
+#### Validate if have geolocation is active:
+
+Fix a bug where when receive a notification with geolocation and the app don't have permission to fetch the geolocation of the user dismiss the notification and don't show to the user.
 
 # EgoiPushLibraryAndroid
 
@@ -33,7 +37,7 @@ There are a few things you must configure in your app in order for the library t
 This library is available through Maven Central. To install it, simply add the following line to your Podfile:
 
 ```gradle
-implementation 'com.egoiapp.egoipushlibrary:egoipushlibrary:3.1.1'
+implementation 'com.egoiapp.egoipushlibrary:egoipushlibrary:3.1.2'
 ```
 
 After installing, you can initialize the library in the **MainActivity** with following instruction:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,6 @@ dependencies {
     implementation "com.google.android.material:material:1.4.0"
     implementation "com.google.firebase:firebase-messaging:23.0.0"
     implementation 'androidx.work:work-runtime-ktx:2.7.1'
-    implementation 'com.egoiapp.egoipushlibrary:egoipushlibrary:3.1.1'
+    implementation 'com.egoiapp.egoipushlibrary:egoipushlibrary:3.1.2'
 //    implementation project(':EgoiPushLibrary')
 }


### PR DESCRIPTION
# What's new in version 3.1.2?

### PATCH

#### Add result return from register token request:

Added the possibility to have the response to the register token request result.

#### Validate if have geolocation is active:

Fix a bug where when receive a notification with geolocation and the app don't have permission to fetch the geolocation of the user dismiss the notification and don't show to the user.
