### PR TITLE
4.0.0

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="$USER_HOME$/.android/avd/Pixel_4_API_31.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-07-14T13:39:57.034013Z" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -15,7 +15,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="DesignSurface">
+    <option name="filePathToZoomLevelMap">
+      <map>
+        <entry key="EgoiPushLibrary/src/main/res/drawable-mdpi/ic_launcher_background.xml" value="0.3975" />
+        <entry key="EgoiPushLibrary/src/main/res/drawable-mdpi/ic_launcher_foreground.xml" value="0.3975" />
+        <entry key="EgoiPushLibrary/src/main/res/layout/activity_egoi_notification.xml" value="0.396875" />
+      </map>
+    </option>
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/EgoiPushLibrary/build.gradle
+++ b/EgoiPushLibrary/build.gradle
@@ -66,7 +66,7 @@ afterEvaluate {
 
                 groupId = 'com.egoiapp.egoipushlibrary'
                 artifactId = 'egoipushlibrary'
-                version = '3.1.5'
+                version = '4.0.0'
 
                 pom {
                     name = "EgoiPushLibrary"

--- a/EgoiPushLibrary/build.gradle
+++ b/EgoiPushLibrary/build.gradle
@@ -6,11 +6,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 32
 
         consumerProguardFiles "consumer-rules.pro"
     }
@@ -29,6 +29,10 @@ android {
 
     kotlinOptions {
         jvmTarget = '1.8'
+    }
+    namespace 'com.egoiapp.egoipushlibrary'
+    buildFeatures {
+        viewBinding true
     }
 }
 
@@ -113,11 +117,12 @@ afterEvaluate {
 dependencies {
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1-native-mt'
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.work:work-runtime-ktx:2.6.0'
+    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.appcompat:appcompat:1.5.0'
+    implementation 'androidx.work:work-runtime-ktx:2.7.1'
     implementation 'androidx.datastore:datastore-preferences:1.0.0'
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0-alpha01'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'com.google.android.gms:play-services-location:19.0.1'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
+    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'com.google.android.gms:play-services-location:20.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 }

--- a/EgoiPushLibrary/src/main/AndroidManifest.xml
+++ b/EgoiPushLibrary/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.egoiapp.egoipushlibrary">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
@@ -9,23 +8,26 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application>
+        <activity
+            android:name=".EgoiNotificationActivity"
+            android:exported="false" />
+
         <activity android:name=".EgoiPushActivity" />
 
         <service
             android:name=".services.GeofenceService"
-            android:exported="false"
-            android:enabled="true">
+            android:enabled="true"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.egoiapp.actions.ACTION_GEOFENCE_EVENT" />
             </intent-filter>
         </service>
-
         <service
             android:name=".services.LocationUpdatesIntentService"
-            android:exported="true"
             android:enabled="true"
-            android:permission="android.permission.ACCESS_FINE_LOCATION|android.permission.FOREGROUND_SERVICE"
-            android:foregroundServiceType="location">
+            android:exported="true"
+            android:foregroundServiceType="location"
+            android:permission="android.permission.ACCESS_FINE_LOCATION|android.permission.FOREGROUND_SERVICE">
             <intent-filter>
                 <action android:name="com.egoiapp.actions.LOCATION_UPDATE" />
             </intent-filter>
@@ -41,7 +43,6 @@
                 <action android:name="com.egoiapp.action.NOTIFICATION_EVENT_CLOSE" />
             </intent-filter>
         </receiver>
-
         <receiver
             android:name=".receivers.LocationBroadcastReceiver"
             android:enabled="true"

--- a/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/EgoiNotificationActivity.kt
+++ b/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/EgoiNotificationActivity.kt
@@ -1,0 +1,171 @@
+package com.egoiapp.egoipushlibrary
+
+import android.app.AlertDialog
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.os.Handler
+import com.egoiapp.egoipushlibrary.receivers.NotificationEventReceiver
+import com.egoiapp.egoipushlibrary.structures.EgoiNotification
+
+class EgoiNotificationActivity : AppCompatActivity() {
+    private var intentProcessed: Boolean = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_egoi_notification)
+        supportActionBar?.hide()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        EgoiPushLibrary.getInstance(this).location.stopService()
+
+        if (intentProcessed) {
+            finishActivity()
+        } else {
+            processIntent()
+        }
+    }
+
+    private fun processIntent() {
+        intentProcessed = true
+
+        if (intent.action == LOCATION_NOTIFICATION_OPEN) {
+            finishActivity()
+        } else if (intent.action in arrayOf(NOTIFICATION_OPEN, NOTIFICATION_ACTION_VIEW)) {
+
+            val egoiNotification = EgoiNotification(
+                title = intent.extras?.getString("title") ?: "",
+                body = intent.extras?.getString("body") ?: "",
+                actionType = intent.extras?.getString("actionType") ?: "",
+                actionText = intent.extras?.getString("actionText") ?: "",
+                actionUrl = intent.extras?.getString("actionUrl") ?: "",
+                actionTextCancel = intent.extras?.getString("actionTextCancel") ?: "",
+                apiKey = intent.extras?.getString("apiKey") ?: "",
+                appId = intent.extras?.getString("appId") ?: "",
+                contactId = intent.extras?.getString("contactId") ?: "",
+                messageHash = intent.extras?.getString("messageHash") ?: "",
+                deviceId = intent.extras?.getInt("deviceId", 0) ?: 0,
+                messageId = intent.extras?.getInt("messageId", 0) ?: 0
+            )
+
+            if (intent.action == NOTIFICATION_OPEN) {
+                if (egoiNotification.actionType != "" && egoiNotification.actionText != "" && egoiNotification.actionUrl != "" && egoiNotification.actionTextCancel != "") {
+                    if (!EgoiPushLibrary.IS_INITIALIZED) {
+                        var intent = Intent(applicationContext, NotificationEventReceiver::class.java)
+                        intent.action = applicationContext.packageName + NotificationEventReceiver.NOTIFICATION_OPEN
+
+                        sendBroadcast(intent)
+
+                        intent = packageManager.getLaunchIntentForPackage(packageName)!!
+                        startActivity(intent)
+
+                        finishActivity()
+                    } else {
+                        if (EgoiPushLibrary.getInstance(applicationContext).dialogCallback != null) {
+                            EgoiPushLibrary.getInstance(applicationContext).dialogCallback?.let {
+                                it(egoiNotification)
+                            }
+                            finishActivity()
+                        } else {
+                            fireDialog(egoiNotification)
+                        }
+                    }
+                } else {
+                    EgoiPushLibrary.getInstance(applicationContext)
+                        .registerEvent(EgoiPushLibrary.OPEN_EVENT, egoiNotification)
+                    finishActivity()
+                }
+            } else if (intent.action == NOTIFICATION_ACTION_VIEW) {
+                EgoiPushLibrary.getInstance(applicationContext)
+                    .registerEvent(EgoiPushLibrary.OPEN_EVENT, egoiNotification)
+
+                if (egoiNotification.actionType == "deeplink") {
+                    EgoiPushLibrary.getInstance(applicationContext).deepLinkCallback?.let {
+                        it(egoiNotification)
+                    }
+                    finishActivity()
+                } else {
+                    val uriIntent =
+                        Intent(Intent.ACTION_VIEW, Uri.parse(egoiNotification.actionUrl))
+                    startActivity(uriIntent)
+                }
+
+                val notificationManager =
+                    getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+                notificationManager.cancel(egoiNotification.messageId)
+            }
+        }
+    }
+
+    private fun fireDialog(egoiNotification: EgoiNotification) {
+        val builder: AlertDialog.Builder =
+            AlertDialog.Builder(this)
+
+        builder.setTitle(egoiNotification.title)
+        builder.setMessage(egoiNotification.body)
+
+        if (
+            egoiNotification.actionType != "" &&
+            egoiNotification.actionText != "" &&
+            egoiNotification.actionUrl != "" &&
+            egoiNotification.actionTextCancel != ""
+        ) {
+            builder.setPositiveButton(egoiNotification.actionText)
+            { _, _ ->
+                EgoiPushLibrary.getInstance(applicationContext)
+                    .registerEvent(EgoiPushLibrary.OPEN_EVENT, egoiNotification)
+
+                if (egoiNotification.actionType == "deeplink") {
+                    EgoiPushLibrary.getInstance(applicationContext).deepLinkCallback?.let {
+                        it(egoiNotification)
+                    }
+                    finishActivity()
+                } else {
+                    startActivity(
+                        Intent(
+                            Intent.ACTION_VIEW,
+                            Uri.parse(egoiNotification.actionUrl)
+                        )
+                    )
+                }
+            }
+
+            builder.setNegativeButton(egoiNotification.actionTextCancel)
+            { _, _ ->
+                EgoiPushLibrary.getInstance(applicationContext)
+                    .registerEvent(EgoiPushLibrary.CANCEL_EVENT, egoiNotification)
+                finishActivity()
+            }
+        }
+
+        val mainHandler = Handler(applicationContext.mainLooper)
+
+        val runnable = Runnable {
+            builder.show()
+        }
+
+        mainHandler.post(runnable)
+    }
+
+    private fun finishActivity() {
+        if (isTaskRoot) {
+            val intent: Intent = packageManager.getLaunchIntentForPackage(packageName)!!
+            startActivity(intent)
+        }
+
+        finish()
+    }
+
+    companion object {
+        const val NOTIFICATION_OPEN: String = "EGOI_NOTIFICATION_OPEN"
+        const val NOTIFICATION_ACTION_VIEW: String = "EGOI_NOTIFICATION_ACTION_VIEW"
+        const val LOCATION_NOTIFICATION_OPEN: String = "EGOI_LOCATION_NOTIFICATION_OPEN"
+    }
+}

--- a/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/EgoiPushLibrary.kt
+++ b/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/EgoiPushLibrary.kt
@@ -70,7 +70,6 @@ class EgoiPushLibrary {
      * Library initializer
      * @param appId The ID of the E-goi's push app
      * @param apiKey The API key of the E-goi's account
-     * @param launchAppAction The action to listen for when the user clicks the notification
      * @param geoEnabled Flag that enables or disabled location related functionalities
      * @param dialogCallback Callback to be invoked in the place of the pop-up
      * @param deepLinkCallback Callback to be invoked when the action type of the notification is a
@@ -80,7 +79,6 @@ class EgoiPushLibrary {
         activityContext: Context,
         appId: String,
         apiKey: String,
-        launchAppAction: String,
         geoEnabled: Boolean = true,
         dialogCallback: ((EgoiNotification) -> Unit)? = null,
         deepLinkCallback: ((EgoiNotification) -> Unit)? = null
@@ -90,16 +88,15 @@ class EgoiPushLibrary {
         this.dialogCallback = dialogCallback
         this.deepLinkCallback = deepLinkCallback
 
-        setDSData(appId, apiKey, launchAppAction, geoEnabled)
+        setDSData(appId, apiKey, geoEnabled)
 
         IS_INITIALIZED = true
     }
 
-    private fun setDSData(appId: String, apiKey: String, openAppAction: String, geoEnabled: Boolean) = runBlocking {
+    private fun setDSData(appId: String, apiKey: String, geoEnabled: Boolean) = runBlocking {
         val egoiPreferences = EgoiPreferences(
             appId = appId,
             apiKey = apiKey,
-            openAppAction = openAppAction,
             geoEnabled = geoEnabled
         )
 

--- a/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/handlers/LocationHandler.kt
+++ b/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/handlers/LocationHandler.kt
@@ -15,6 +15,7 @@ import com.egoiapp.egoipushlibrary.services.LocationUpdatesIntentService
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
 
 /**
  * Class responsible for handling operations related to the location
@@ -28,7 +29,7 @@ class LocationHandler(
     private val locationRequest: LocationRequest = LocationRequest.create().apply {
         interval = UPDATE_INTERVAL_IN_MILLISECONDS
         fastestInterval = FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS
-        priority = LocationRequest.PRIORITY_HIGH_ACCURACY
+        priority = Priority.PRIORITY_HIGH_ACCURACY
     }
 
     fun requestLocationUpdates() {

--- a/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/receivers/NotificationEventReceiver.kt
+++ b/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/receivers/NotificationEventReceiver.kt
@@ -4,15 +4,9 @@ import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.workDataOf
 import com.egoiapp.egoipushlibrary.EgoiPushLibrary
 import com.egoiapp.egoipushlibrary.structures.EgoiNotification
-import com.egoiapp.egoipushlibrary.structures.EgoiPreferences
-import com.egoiapp.egoipushlibrary.workers.FireDialogWorker
-import kotlinx.coroutines.runBlocking
-import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 
 /**
  * Receiver responsible for handling the clicks on notifications triggered by a geofence
@@ -24,131 +18,56 @@ class NotificationEventReceiver : BroadcastReceiver() {
      * Check if the action is a notification click and displays a dialog to the user
      */
     override fun onReceive(context: Context?, intent: Intent?) {
-        if (context != null && intent != null) {
+        if (
+            context != null && intent != null &&
+            (intent.action == context.applicationContext.packageName + NOTIFICATION_OPEN || intent.action == context.applicationContext.packageName + NOTIFICATION_CLOSE)
+        ) {
             val extras = intent.extras
 
-            if (extras != null) {
-                if (!EgoiPushLibrary.getInstance(context)
-                        .isAppOnForeground() && intent.action !== NOTIFICATION_EVENT_CLOSE
-                ) {
-                    runBlocking {
-                        val preferences: EgoiPreferences =
-                            EgoiPushLibrary.getInstance(context).dataStore.getDSPreferences()
+            egoiNotification = EgoiNotification(
+                title = extras?.getString("title") ?: "",
+                body = extras?.getString("body") ?: "",
+                actionType = extras?.getString("actionType") ?: "",
+                actionText = extras?.getString("actionText") ?: "",
+                actionUrl = extras?.getString("actionUrl") ?: "",
+                actionTextCancel = extras?.getString("actionTextCancel") ?: "",
+                apiKey = extras?.getString("apiKey") ?: "",
+                appId = extras?.getString("appId") ?: "",
+                contactId = extras?.getString("contactId") ?: "",
+                messageHash = extras?.getString("messageHash") ?: "",
+                deviceId = extras?.getInt("deviceId", 0) ?: 0,
+                messageId = extras?.getInt("messageId", 0) ?: 0
+            )
 
-                        var action = LAUNCH_APP
-
-                        if (preferences.openAppAction != "") {
-                            action = preferences.openAppAction
-                        }
-
-                        val activityIntent = Intent(action)
-                        activityIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-
-                        context.startActivity(activityIntent)
-                    }
-                }
-
-                egoiNotification = EgoiNotification(
-                    title = extras.getString("title") ?: "",
-                    body = extras.getString("body") ?: "",
-                    actionType = extras.getString("actionType") ?: "",
-                    actionText = extras.getString("actionText") ?: "",
-                    actionUrl = extras.getString("actionUrl") ?: "",
-                    actionTextCancel = extras.getString("actionTextCancel") ?: "",
-                    apiKey = extras.getString("apiKey") ?: "",
-                    appId = extras.getString("appId") ?: "",
-                    contactId = extras.getString("contactId") ?: "",
-                    messageHash = extras.getString("messageHash") ?: "",
-                    deviceId = extras.getInt("deviceId", 0),
-                    messageId = extras.getInt("messageId", 0)
-                )
-
-                if (intent.action === NOTIFICATION_EVENT_CLOSE) {
-                    EgoiPushLibrary.getInstance(context.applicationContext)
-                        .registerEvent(EgoiPushLibrary.CANCEL_EVENT, egoiNotification)
-                    dismissNotification(context.applicationContext)
-                    return
-                }
-
-                val thread = Thread {
+            if (intent.action == context.applicationContext.packageName + NOTIFICATION_OPEN) {
+                thread {
                     while (!EgoiPushLibrary.IS_INITIALIZED) {
-                        Thread.sleep(300)
+                        Thread.sleep(500)
                     }
 
-                    if (intent.action == NOTIFICATION_OPEN) {
-                        if (egoiNotification.actionType != "" && egoiNotification.actionText != "" && egoiNotification.actionUrl != "" && egoiNotification.actionTextCancel != "") {
-                            if (EgoiPushLibrary.getInstance(context.applicationContext).dialogCallback != null) {
-                                EgoiPushLibrary.getInstance(context.applicationContext).dialogCallback?.let {
-                                    it(egoiNotification)
-                                }
-                            } else {
-                                EgoiPushLibrary.getInstance(context.applicationContext).requestWork(
-                                    workRequest = OneTimeWorkRequestBuilder<FireDialogWorker>()
-                                        .setInitialDelay(1, TimeUnit.SECONDS)
-                                        .setInputData(
-                                            workDataOf(
-                                                /* Dialog Data */
-                                                "title" to egoiNotification.title,
-                                                "body" to egoiNotification.body,
-                                                "actionType" to egoiNotification.actionType,
-                                                "actionText" to egoiNotification.actionText,
-                                                "actionUrl" to egoiNotification.actionUrl,
-                                                "actionTextCancel" to egoiNotification.actionTextCancel,
-                                                /* Event Data*/
-                                                "apiKey" to egoiNotification.apiKey,
-                                                "appId" to egoiNotification.appId,
-                                                "contactId" to egoiNotification.contactId,
-                                                "messageHash" to egoiNotification.messageHash,
-                                                "deviceId" to egoiNotification.deviceId,
-                                                "messageId" to egoiNotification.messageId
-                                            )
-                                        )
-                                        .build()
-                                )
-                            }
-                        } else {
-                            EgoiPushLibrary.getInstance(context.applicationContext)
-                                .registerEvent(EgoiPushLibrary.OPEN_EVENT, egoiNotification)
+                    if (EgoiPushLibrary.getInstance(context.applicationContext).dialogCallback != null) {
+                        EgoiPushLibrary.getInstance(context.applicationContext).dialogCallback?.let {
+                            it(egoiNotification)
                         }
-                    }
-
-                    if (intent.action === NOTIFICATION_EVENT_VIEW) {
-                        EgoiPushLibrary.getInstance(context.applicationContext)
-                            .registerEvent(EgoiPushLibrary.OPEN_EVENT, egoiNotification)
-
-                        if (egoiNotification.actionType == "deeplink") {
-                            EgoiPushLibrary.getInstance(context.applicationContext).deepLinkCallback?.let {
-                                it(egoiNotification)
-                            }
-                        } else {
-                            val uriIntent =
-                                Intent(Intent.ACTION_VIEW, Uri.parse(egoiNotification.actionUrl))
-                            uriIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-
-                            context.applicationContext.startActivity(uriIntent)
-                        }
-
-                        dismissNotification(context.applicationContext)
                     }
                 }
+            }
 
-                thread.start()
+            if (intent.action == context.applicationContext.packageName + NOTIFICATION_CLOSE) {
+                EgoiPushLibrary.getInstance(context.applicationContext)
+                    .registerEvent(EgoiPushLibrary.CANCEL_EVENT, egoiNotification)
+
+                val notificationManager =
+                    context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+                notificationManager.cancel(egoiNotification.messageId)
             }
         }
     }
 
-    private fun dismissNotification(context: Context) {
-        val notificationManager =
-            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-        notificationManager.cancel(egoiNotification.messageId)
-    }
-
     companion object {
-        const val NOTIFICATION_OPEN: String = "com.egoiapp.action.NOTIFICATION_OPEN"
-        const val NOTIFICATION_EVENT_VIEW: String = "com.egoiapp.action.NOTIFICATION_EVENT_VIEW"
-        const val NOTIFICATION_EVENT_CLOSE: String = "com.egoiapp.action.NOTIFICATION_EVENT_CLOSE"
-        var LAUNCH_APP: String = "com.egoiapp.action.LAUNCH_APP"
+        const val NOTIFICATION_OPEN: String = ".EGOI_NOTIFICATION_OPEN"
+        const val NOTIFICATION_CLOSE: String = ".EGOI_NOTIFICATION_CLOSE"
     }
 
 }

--- a/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/services/GeofenceService.kt
+++ b/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/services/GeofenceService.kt
@@ -18,22 +18,24 @@ class GeofenceService : Service() {
             Log.d(TAG, "Geofence service started...")
             val geofencingEvent = GeofencingEvent.fromIntent(intent)
 
-            if (geofencingEvent.hasError()) {
-                Log.e("GEO_EVENT", geofencingEvent.errorCode.toString())
-                return START_NOT_STICKY
-            }
+            if (geofencingEvent != null) {
+                if (geofencingEvent.hasError()) {
+                    Log.e("GEO_EVENT", geofencingEvent.errorCode.toString())
+                    return START_NOT_STICKY
+                }
 
-            if (geofencingEvent.geofenceTransition == Geofence.GEOFENCE_TRANSITION_ENTER) {
-                val fenceId = when {
-                    geofencingEvent.triggeringGeofences.isNotEmpty() ->
-                        geofencingEvent.triggeringGeofences[0].requestId
-                    else -> {
+                if (geofencingEvent.geofenceTransition == Geofence.GEOFENCE_TRANSITION_ENTER) {
+                    if (geofencingEvent.triggeringGeofences != null && geofencingEvent.triggeringGeofences!!.isNotEmpty()) {
+                        EgoiPushLibrary.getInstance(applicationContext)
+                            .sendGeoNotification(geofencingEvent.triggeringGeofences!![0].requestId)
+                    } else {
                         Log.e("GEO_EVENT", "No Geofence Trigger Found! Abort mission!")
                         return START_NOT_STICKY
                     }
                 }
-
-                EgoiPushLibrary.getInstance(applicationContext).sendGeoNotification(fenceId)
+            } else {
+                Log.e("GEO_EVENT", "Failed to get a GeofencingEvent objet from the current intent.")
+                return START_NOT_STICKY
             }
         }
 

--- a/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/services/LocationUpdatesIntentService.kt
+++ b/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/services/LocationUpdatesIntentService.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
+import com.egoiapp.egoipushlibrary.EgoiNotificationActivity
 import com.egoiapp.egoipushlibrary.EgoiPushLibrary
 import com.egoiapp.egoipushlibrary.R
 import com.egoiapp.egoipushlibrary.handlers.LocationHandler
@@ -16,6 +17,7 @@ import com.egoiapp.egoipushlibrary.structures.EgoiPreferences
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
 import java.text.DateFormat
 import java.util.*
 
@@ -45,7 +47,7 @@ class LocationUpdatesIntentService : Service() {
         locationRequest = LocationRequest.create().apply {
             interval = LocationHandler.UPDATE_INTERVAL_IN_MILLISECONDS
             fastestInterval = LocationHandler.FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS
-            priority = LocationRequest.PRIORITY_HIGH_ACCURACY
+            priority = Priority.PRIORITY_BALANCED_POWER_ACCURACY
         }
     }
 
@@ -96,31 +98,22 @@ class LocationUpdatesIntentService : Service() {
     }
 
     private fun createActivityPendingIntent(): PendingIntent {
-        val preferences: EgoiPreferences =
-            EgoiPushLibrary.getInstance(applicationContext).dataStore.getDSPreferences()
-
-        var action = NotificationEventReceiver.LAUNCH_APP
-
-        if (preferences.openAppAction != "") {
-            action = preferences.openAppAction
-        }
-
-        val activityIntent = Intent(action)
-        activityIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        val activityIntent = Intent(applicationContext, EgoiNotificationActivity::class.java)
+        activityIntent.action = EgoiNotificationActivity.LOCATION_NOTIFICATION_OPEN
 
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             PendingIntent.getActivity(
                 this,
                 0,
                 activityIntent,
-                PendingIntent.FLAG_IMMUTABLE
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         } else {
             PendingIntent.getActivity(
                 this,
                 0,
                 activityIntent,
-                0
+                PendingIntent.FLAG_UPDATE_CURRENT
             )
         }
     }

--- a/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/structures/EgoiPreferences.kt
+++ b/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/structures/EgoiPreferences.kt
@@ -6,7 +6,6 @@ import org.json.JSONObject
 data class EgoiPreferences(
     var appId: String = "",
     var apiKey: String = "",
-    var openAppAction: String = "",
     var geoEnabled: Boolean = true
 ) {
     /**
@@ -18,7 +17,6 @@ data class EgoiPreferences(
         json.put("app-id", appId)
         json.put("api-key", apiKey)
         json.put("geo-enabled", geoEnabled)
-        json.put("open-app-action", openAppAction)
 
         return json.toString()
     }
@@ -33,7 +31,6 @@ data class EgoiPreferences(
             appId = json.getString("app-id"),
             apiKey = json.getString("api-key"),
             geoEnabled = json.getBoolean("geo-enabled"),
-            openAppAction = json.getString("open-app-action"),
         )
     }
 }

--- a/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/workers/FireDialogWorker.kt
+++ b/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/workers/FireDialogWorker.kt
@@ -20,9 +20,6 @@ class FireDialogWorker(
     private lateinit var egoiNotification: EgoiNotification
 
     override fun doWork(): Result {
-        val builder: AlertDialog.Builder =
-            AlertDialog.Builder(EgoiPushLibrary.getInstance(context).activityContext)
-
         egoiNotification = EgoiNotification(
             title = inputData.getString("title") ?: "",
             body = inputData.getString("body") ?: "",
@@ -38,6 +35,9 @@ class FireDialogWorker(
             messageId = inputData.getInt("messageId", 0)
         )
 
+        val builder: AlertDialog.Builder =
+            AlertDialog.Builder(context)
+
         builder.setTitle(egoiNotification.title)
         builder.setMessage(egoiNotification.body)
 
@@ -49,7 +49,7 @@ class FireDialogWorker(
         ) {
             builder.setPositiveButton(egoiNotification.actionText)
             { _, _ ->
-                EgoiPushLibrary.getInstance(context.applicationContext)
+                EgoiPushLibrary.getInstance(context)
                     .registerEvent(EgoiPushLibrary.OPEN_EVENT, egoiNotification)
 
                 if (egoiNotification.actionType == "deeplink") {
@@ -68,12 +68,12 @@ class FireDialogWorker(
 
             builder.setNegativeButton(egoiNotification.actionTextCancel)
             { _, _ ->
-                EgoiPushLibrary.getInstance(context.applicationContext)
+                EgoiPushLibrary.getInstance(context)
                     .registerEvent(EgoiPushLibrary.CANCEL_EVENT, egoiNotification)
             }
         }
 
-        val mainHandler = Handler(EgoiPushLibrary.getInstance(context).activityContext.mainLooper)
+        val mainHandler = Handler(context.applicationContext.mainLooper)
 
         val runnable = Runnable {
             builder.show()

--- a/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/workers/FireNotificationWorker.kt
+++ b/EgoiPushLibrary/src/main/java/com/egoiapp/egoipushlibrary/workers/FireNotificationWorker.kt
@@ -13,6 +13,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import com.egoiapp.egoipushlibrary.EgoiNotificationActivity
 import com.egoiapp.egoipushlibrary.EgoiPushLibrary
 import com.egoiapp.egoipushlibrary.receivers.NotificationEventReceiver
 import com.egoiapp.egoipushlibrary.structures.EgoiNotification
@@ -106,8 +107,10 @@ class FireNotificationWorker(
      * @return Local notification
      */
     private fun buildNotification(): Notification {
-        val intent = Intent(context, NotificationEventReceiver::class.java)
-        intent.action = NotificationEventReceiver.NOTIFICATION_OPEN
+        val intent = Intent(context, EgoiNotificationActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        intent.action = EgoiNotificationActivity.NOTIFICATION_OPEN
+
         // Dialog Data
         intent.putExtra("title", title)
         intent.putExtra("body", text)
@@ -123,23 +126,23 @@ class FireNotificationWorker(
         intent.putExtra("deviceId", deviceId)
 
         val pendingIntent: PendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            PendingIntent.getBroadcast(
+            PendingIntent.getActivity(
                 context,
-                0,
+                ACTIVITY_REQUEST_CODE,
                 intent,
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         } else {
-            PendingIntent.getBroadcast(
+            PendingIntent.getActivity(
                 context,
-                0,
+                ACTIVITY_REQUEST_CODE,
                 intent,
                 PendingIntent.FLAG_UPDATE_CURRENT
             )
         }
 
-        val viewIntent = Intent(context, NotificationEventReceiver::class.java)
-        viewIntent.action = NotificationEventReceiver.NOTIFICATION_EVENT_VIEW
+        val viewIntent = Intent(context, EgoiNotificationActivity::class.java)
+        viewIntent.action = EgoiNotificationActivity.NOTIFICATION_ACTION_VIEW
         // Dialog Data
         viewIntent.putExtra("title", title)
         viewIntent.putExtra("body", text)
@@ -156,23 +159,23 @@ class FireNotificationWorker(
         viewIntent.putExtra("messageId", messageId)
 
         val viewPendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            PendingIntent.getBroadcast(
+            PendingIntent.getActivity(
                 context,
-                0,
+                ACTIVITY_REQUEST_CODE,
                 viewIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         } else {
-            PendingIntent.getBroadcast(
+            PendingIntent.getActivity(
                 context,
-                0,
+                ACTIVITY_REQUEST_CODE,
                 viewIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT
             )
         }
 
         val closeIntent = Intent(context, NotificationEventReceiver::class.java)
-        closeIntent.action = NotificationEventReceiver.NOTIFICATION_EVENT_CLOSE
+        closeIntent.action = context.applicationContext.packageName + NotificationEventReceiver.NOTIFICATION_CLOSE
         // Dialog Data
         closeIntent.putExtra("title", title)
         closeIntent.putExtra("body", text)
@@ -193,7 +196,7 @@ class FireNotificationWorker(
                 context,
                 0,
                 closeIntent,
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         } else {
             PendingIntent.getBroadcast(
@@ -277,5 +280,9 @@ class FireNotificationWorker(
 
         EgoiPushLibrary.getInstance(context.applicationContext)
             .registerEvent(EgoiPushLibrary.RECEIVED_EVENT, egoiNotification)
+    }
+
+    companion object {
+        const val ACTIVITY_REQUEST_CODE: Int = 873264872
     }
 }

--- a/EgoiPushLibrary/src/main/res/layout/activity_egoi_notification.xml
+++ b/EgoiPushLibrary/src/main/res/layout/activity_egoi_notification.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".EgoiNotificationActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/EgoiPushLibrary/src/main/res/values/strings.xml
+++ b/EgoiPushLibrary/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="launch_activity">Launch activity</string>
     <string name="stop_location_updates">Stop location updates</string>
     <string name="application_using_location">This application is using your location</string>
+    <string name="title_activity_egoi_notification">EgoiNotificationActivity</string>
 </resources>

--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
-# What's new in version 3.1.5?
+# What's new in version 4.0.0?
+
+### MAJOR
+
+#### From a BroadcastReceiver to an Activity:
+
+With the release of Android 12, some changes were required to be made to the logic we were using to 
+process the interactions of the user with the notification. On this new version, it is not possible 
+to invoke an activity through an app component (receivers, services) when a notification is tapped.
+
+To solve this problem, we added a new activity that is called in every E-goi notification's 
+interaction. This activity is responsible for handling the events, dialogs and callbacks.
+
+With this new solution, some changes are required to be made in your code:
+
+1. You no longer need to declare the launch action on the intent filter of the desired activity in
+the manifest since it will always invoke the new activity. When closing the activity, we will 
+launch the initial activity configured on the app.
+
+2. You no longer have to declare the launchAppAction in the SDK initializer.
 
 ### PATCH
 
-#### Refactor Datastore logic:
+#### Update of dependencies:
 
-Refactored the logic related to Datastore to prevent NullPointerExceptions when accessing the preferences.
-
-#### Text truncated in notifications:
-
-Fixed a bug where the content of a notification was being truncated the the text was too big.
-
-#### registerEvent method is now public
-
-The registerEvent method is now public so that you can call it when implementing custom logic in the
-callbacks.
+We updated all the dependencies that the SDK uses to the latest versions and made the required 
+adjustments on our code.
 
 # EgoiPushLibraryAndroid
 
@@ -42,7 +53,7 @@ There are a few things you must configure in your app in order for the library t
 This library is available through Maven Central. To install it, simply add the following line to your Podfile:
 
 ```gradle
-implementation 'com.egoiapp.egoipushlibrary:egoipushlibrary:3.1.5'
+implementation 'com.egoiapp.egoipushlibrary:egoipushlibrary:4.0.0'
 ```
 
 After installing, you can initialize the library in the **MainActivity** with following instruction:
@@ -62,7 +73,6 @@ class MainActivity : EgoiPushActivity() {
             appId = "abc",
             apiKey = "abc",
             geoEnabled = true,
-            launchAppAction = "abc",
             dialogCallback = fun (link: EgoiNotification) {
                 Log.d("DIALOG", link.toString())
             },
@@ -77,20 +87,6 @@ class MainActivity : EgoiPushActivity() {
 **Note:** In the example above you can see that the MainActivity is extending our **EgoiPushActivity**. This is not
 required but recommended since this class handles the life cycle of our location service and handles the responses of
 the user to the location access requests.
-
-## Target launch Activity
-
-To define what activity you want to launch when a notification is clicked, you need to add an action to the 
-intent filter of the desired activity. You should than send this action as a parameter in the SDK initialization so we can listen to it:
-
-```xml
-<intent-filter>
-   ...
-   <action android:name="abc" />
-   <category android:name="android.intent.category.DEFAULT" />
-   ...
-</intent-filter>
-```
 
 ## Disable location services
 
@@ -226,13 +222,6 @@ Responsible for initializing the library. The call of this method is required.
    <td>apiKey</td>
    <td>String</td>
    <td>The API key of your E-goi account.</td>
-   <td>true</td>
-   <td>---</td>
-</tr>
-<tr>
-   <td>launchAppAction</td>
-   <td>String</td>
-   <td>The action to listen for when the user clicks the notification</td>
    <td>true</td>
    <td>---</td>
 </tr>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.egoiapp.egoipushlibraryandroid"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -29,17 +29,18 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'com.egoiapp.egoipushlibraryandroid'
 }
 
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "androidx.core:core-ktx:1.7.0"
-    implementation "androidx.appcompat:appcompat:1.4.1"
-    implementation "androidx.constraintlayout:constraintlayout:2.1.3"
+    implementation "androidx.core:core-ktx:1.8.0"
+    implementation "androidx.appcompat:appcompat:1.5.0"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
     implementation "androidx.multidex:multidex:2.0.1"
-    implementation "com.google.android.material:material:1.5.0"
-    implementation "com.google.firebase:firebase-messaging:23.0.0"
+    implementation "com.google.android.material:material:1.6.1"
+    implementation "com.google.firebase:firebase-messaging:23.0.7"
     implementation 'androidx.work:work-runtime-ktx:2.7.1'
     implementation 'com.egoiapp.egoipushlibrary:egoipushlibrary:3.1.5'
 //    implementation project(':EgoiPushLibrary')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,6 @@ dependencies {
     implementation "com.google.android.material:material:1.6.1"
     implementation "com.google.firebase:firebase-messaging:23.0.7"
     implementation 'androidx.work:work-runtime-ktx:2.7.1'
-    implementation 'com.egoiapp.egoipushlibrary:egoipushlibrary:3.1.5'
+    implementation 'com.egoiapp.egoipushlibrary:egoipushlibrary:4.0.0'
 //    implementation project(':EgoiPushLibrary')
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.egoiapp.egoipushlibraryandroid">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
@@ -31,11 +29,6 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
-                <!-- Add this two lines do the intent filter of the activity that you want to launch
-                when the notification is clicked -->
-                <action android:name="abc" />
-                <category android:name="android.intent.category.DEFAULT" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>

--- a/app/src/main/java/com/egoiapp/egoipushlibraryandroid/MainActivity.kt
+++ b/app/src/main/java/com/egoiapp/egoipushlibraryandroid/MainActivity.kt
@@ -22,7 +22,6 @@ class MainActivity : EgoiPushActivity() {
             activityContext = this,
             appId = "abc",
             apiKey = "abc",
-            launchAppAction = "abc",
             deepLinkCallback = fun (link: EgoiNotification) {
                 Log.d("DEEP_LINK", link.toString())
             }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.6.10"
+    ext.kotlin_version = "1.7.10"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.google.gms:google-services:4.3.13'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip


### PR DESCRIPTION
# What's new in version 4.0.0?

### MAJOR

#### From a BroadcastReceiver to an Activity:

With the release of Android 12, some changes were required to be made to the logic we were using to 
process the interactions of the user with the notification. On this new version, it is not possible 
to invoke an activity through an app component (receivers, services) when a notification is tapped.

To solve this problem, we added a new activity that is called in every E-goi notification's 
interaction. This activity is responsible for handling the events, dialogs and callbacks.

With this new solution, some changes are required to be made in your code:

1. You no longer need to declare the launch action on the intent filter of the desired activity in
the manifest since it will always invoke the new activity. When closing the activity, we will 
launch the initial activity configured on the app.

2. You no longer have to declare the launchAppAction in the SDK initializer.

### PATCH

#### Update of dependencies:

We updated all the dependencies that the SDK uses to the latest versions and made the required 
adjustments on our code.